### PR TITLE
Fix random entry generator

### DIFF
--- a/content/content.create.php
+++ b/content/content.create.php
@@ -39,7 +39,6 @@
             if (isset($_GET['s']) && !empty($_GET['s'])) {
                 $s = General::sanitize($_GET['s']);
                 $sectionId = 0;
-                $authorId = Symphony::Author()->get('id');
                 $section = NULL;
                 if (ctype_digit($s)) {
                     $sectionId = General::intval($s);
@@ -57,7 +56,6 @@
                 }
                 $fields = $section->fetchFields();
                 $entry = EntryManager::create();
-                $entry->set('author_id', $authorId);
                 $entry->set('section_id', $sectionId);
                 foreach ($fields as $field) {
                     $adapter = FieldAdapterManager::get($field->get('type'));

--- a/content/content.create.php
+++ b/content/content.create.php
@@ -39,6 +39,7 @@
             if (isset($_GET['s']) && !empty($_GET['s'])) {
                 $s = General::sanitize($_GET['s']);
                 $sectionId = 0;
+                $authorId = Symphony::Author()->get('id');
                 $section = NULL;
                 if (ctype_digit($s)) {
                     $sectionId = General::intval($s);
@@ -56,6 +57,7 @@
                 }
                 $fields = $section->fetchFields();
                 $entry = EntryManager::create();
+                $entry->set('author_id', $authorId);
                 $entry->set('section_id', $sectionId);
                 foreach ($fields as $field) {
                     $adapter = FieldAdapterManager::get($field->get('type'));

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -19,6 +19,10 @@
         </author>
     </authors>
     <releases>
+        <release version="1.1.7" date="2016-08-08" min="2.6.0" max="2.x.x">
+            - Supported on PHP 7
+            - Fixed author_id is missing
+        </release>
         <release version="1.1.6" date="2016-03-07" min="2.6.0" max="2.x.x">
             - Fixed a the redirection url again: should be 'created' not 'saved'
         </release>


### PR DESCRIPTION
Random_entry_generator is now supported on PHP 7
Fixed issue with author_id missing.
